### PR TITLE
feat: validate Supabase env vars at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Ein kleines, dunkles Dashboard für `public.measurements` mit Live-Updates (INSE
    NEXT_PUBLIC_SUPABASE_URL=https://<PROJECT>.supabase.co
    NEXT_PUBLIC_SUPABASE_ANON_KEY=<ANON_KEY>
    ```
+   Fehlt eine der Variablen, schlägt der Build fehl.
 3. Dev-Server starten:
    ```bash
    npm run dev

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+})
+
+const env = envSchema.safeParse(process.env)
+
+if (!env.success) {
+  throw new Error('Supabase-Umgebungsvariablen fehlen. Bitte .env.local prüfen.')
+}
+
+export const { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY } = env.data

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,18 +1,15 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import {
+  NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_SUPABASE_URL,
+} from './env'
 
 let cachedClient: SupabaseClient | null = null
 
 export function getSupabaseClient(): SupabaseClient {
   if (cachedClient) return cachedClient
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error('Supabase-Umgebungsvariablen fehlen. Bitte .env.local prüfen.')
-  }
-
-  cachedClient = createClient(supabaseUrl, supabaseAnonKey, {
+  cachedClient = createClient(NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, {
     auth: { persistSession: false },
   })
   return cachedClient

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "14",
         "postcss": "^8.4.41",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^20.12.12",
@@ -1341,6 +1342,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "14",
     "postcss": "^8.4.41",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
@@ -23,4 +24,3 @@
     "typescript": "^5.5.4"
   }
 }
-


### PR DESCRIPTION
## Summary
- validate NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY using zod
- use validated env values in Supabase client
- note in README that missing variables fail the build

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af605f00f0832f8fb6bf97a1a0af08